### PR TITLE
feature: String interpolation

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -789,6 +789,7 @@ make_ssa_check_pass(PassFlag) ->
 
 standard_passes() ->
     [?pass(transform_module),
+     ?pass(desugar_interpolation),
 
      {iff,makedep_side_effect,?pass(makedep_and_output)},
      {iff,makedep,[
@@ -1248,6 +1249,9 @@ strip_columns(Code) ->
          Form ->
              erl_parse:map_anno(F, Form)
      end || Form <- Code].
+
+desugar_interpolation(Code, #compile{options=Opt}=St) ->
+  {ok, erl_desugar_interpolation:module(Code, Opt), St}.
 
 get_core_transforms(Opts) -> [M || {core_transform,M} <- Opts].
 

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -67,6 +67,7 @@ MODULES= \
 	erl_error \
 	erl_eval \
 	erl_expand_records \
+	erl_desugar_interpolation \
 	erl_features \
 	erl_internal \
 	erl_lint \

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -1930,6 +1930,10 @@ token_src({char,_,C}) ->
 token_src({string, _, X}) ->
     io_lib:write_string(X);
 token_src({_, _, X}) ->
+    io_lib:format("~w", [X]);
+token_src({_, _, _, X}) ->
+    io_lib:format("~w", [X]);
+token_src({_, _, _, _, X}) ->
     io_lib:format("~w", [X]).
 
 stringify1([]) ->

--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -512,6 +512,12 @@ expr({'maybe',Anno,Es,{'else',_,Cs}}, Bs0, Lf, Ef, RBs, FUVs) ->
                     apply_error({else_clause,Val}, ?STACKTRACE, Anno, Bs0, Ef, RBs)
             end
     end;
+expr({'interpolation',_,_,_,_}=Interpolation, Bs, Lf, Ef, RBs, FUVs) ->
+    DesugaredInterpolation = erl_desugar_interpolation:expr(Interpolation),
+    expr(DesugaredInterpolation, Bs, Lf, Ef, RBs, FUVs);
+expr({'interpolation_no_subs',_,_,_}=Interpolation, Bs, Lf, Ef, RBs, FUVs) ->
+    DesugaredInterpolation = erl_desugar_interpolation:expr(Interpolation),
+    expr(DesugaredInterpolation, Bs, Lf, Ef, RBs, FUVs);
 expr({op,Anno,Op,A0}, Bs0, Lf, Ef, RBs, FUVs) ->
     {value,A,Bs} = expr(A0, Bs0, Lf, Ef, none, FUVs),
     eval_op(Op, A, Anno, Bs, Ef, RBs);

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2553,6 +2553,10 @@ expr({'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}}, Vt, St) ->
     Evt2 = vtmerge(Evt0, Evt1),
     Cvt2 = vtmerge(Cvt0, Cvt1),
     {vtmerge(Evt2, Cvt2),St2};
+expr({'interpolation',_Anno,_Head,Conts,_Tail}, Vt, St) ->
+    expr_list([SubsExpr || {interpolation_subs,_,SubsExpr} <- Conts], Vt, St);
+expr({'interpolation_no_subs',_Anno,_Kind,_IsDebug,_Str}, _Vt, St) ->
+    {[],St};
 %% No comparison or boolean operators yet.
 expr({op,_Anno,_Op,A}, Vt, St) ->
     expr(A, Vt, St);

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -45,6 +45,7 @@
              erl_anno,
 	     erl_bits,
 	     erl_compile,
+             erl_desugar_interpolation,
 	     erl_error,
 	     erl_eval,
              erl_expand_records,

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -27,6 +27,7 @@ MODULES= \
 	edlin_context_SUITE \
 	epp_SUITE \
 	erl_anno_SUITE \
+	erl_desugar_interpolation_SUITE \
 	erl_eval_SUITE \
 	erl_expand_records_SUITE \
 	erl_internal_SUITE \

--- a/lib/stdlib/test/erl_desugar_interpolation_SUITE.erl
+++ b/lib/stdlib/test/erl_desugar_interpolation_SUITE.erl
@@ -1,0 +1,575 @@
+-module(erl_desugar_interpolation_SUITE).
+
+-export([all/0,suite/0]).
+
+-export([empty/1, head/1, head_subs_no_tail/1, head_subs_tail/1,
+         head_subs_cont_subs_tail/1, multiline_head_subs_cont_subs_tail/1,
+         lots_of_subs/1, tilde_can_be_escaped/1,
+         unicode_list_string_subs_in_list/1, utf8_binary_string_subs_in_list/1,
+         unicode_list_string_subs_in_tuple/1, utf8_binary_string_subs_in_tuple/1,
+         variable_subs/1, macro_subs/1, special_characters/1, all_types_subs/1,
+         all_production_format_types_subs/1, floats_round_trip_and_are_the_same_between_lists_and_binaries/1,
+         block_substitutions/1, function_call_substitutions/1,
+         back_to_back_substitutions/1,
+         homogenous_interpolations_inside_interpolations/1,
+         heterogenous_interpolations_inside_interpolations/1]).
+
+-include_lib("stdlib/include/assert.hrl").
+
+suite() ->
+    [{timetrap,{minutes,1}}].
+
+all() ->
+    [ empty, head, head_subs_no_tail, head_subs_tail,
+      head_subs_cont_subs_tail, multiline_head_subs_cont_subs_tail,
+      lots_of_subs, tilde_can_be_escaped,
+      unicode_list_string_subs_in_list, utf8_binary_string_subs_in_list,
+      unicode_list_string_subs_in_tuple, utf8_binary_string_subs_in_tuple,
+      variable_subs, macro_subs, special_characters, all_types_subs,
+      all_production_format_types_subs, floats_round_trip_and_are_the_same_between_lists_and_binaries,
+      block_substitutions, function_call_substitutions,
+      back_to_back_substitutions,
+      homogenous_interpolations_inside_interpolations,
+      heterogenous_interpolations_inside_interpolations
+    ].
+
+-define(assertEqualStr(A,B), ?assertEqual(A,lists:flatten(B))).
+
+empty(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<>>,
+    bf""
+  ),
+  ?assertEqualStr(
+    "",
+    lf""
+  ),
+  ?assertEqual(
+    <<>>,
+    bd""
+  ),
+  ?assertEqualStr(
+    "",
+    ld""
+  ).
+
+head(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"A head"/utf8>>,
+    bf"A head"
+  ),
+  ?assertEqualStr(
+    "A head",
+    lf"A head"
+  ),
+  ?assertEqual(
+    <<"A head"/utf8>>,
+    bd"A head"
+  ),
+  ?assertEqualStr(
+    "A head",
+    ld"A head"
+  ).
+
+head_subs_tail(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Two plus two is 4!"/utf8>>,
+    bf"Two plus two is ~2 + 2~!"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4!",
+    lf"Two plus two is ~2 + 2~!"
+  ),
+  ?assertEqual(
+    <<"Two plus two is 4!"/utf8>>,
+    bd"Two plus two is ~2 + 2~!"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4!",
+    ld"Two plus two is ~2 + 2~!"
+  ).
+
+head_subs_no_tail(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Two plus two is 4"/utf8>>,
+    bf"Two plus two is ~2 + 2~"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4",
+    lf"Two plus two is ~2 + 2~"
+  ),
+  ?assertEqual(
+    <<"Two plus two is 4"/utf8>>,
+    bd"Two plus two is ~2 + 2~"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4",
+    ld"Two plus two is ~2 + 2~"
+  ).
+
+head_subs_cont_subs_tail(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Two plus two is 4, and three times three is 9!"/utf8>>,
+    bf"Two plus two is ~2 + 2~, and three times three is ~3 * 3~!"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4, and three times three is 9!",
+    lf"Two plus two is ~2 + 2~, and three times three is ~3 * 3~!"
+  ),
+  ?assertEqual(
+    <<"Two plus two is 4, and three times three is 9!"/utf8>>,
+    bd"Two plus two is ~2 + 2~, and three times three is ~3 * 3~!"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4, and three times three is 9!",
+    ld"Two plus two is ~2 + 2~, and three times three is ~3 * 3~!"
+  ).
+
+multiline_head_subs_cont_subs_tail(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Two plus two is 4,
+       and three times three is 9!"/utf8>>,
+    bf"Two plus two is ~2 + 2~,
+       and three times three is ~3 * 3~!"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4,
+       and three times three is 9!",
+    lf"Two plus two is ~2 + 2~,
+       and three times three is ~3 * 3~!"
+  ),
+  ?assertEqual(
+    <<"Two plus two is 4,
+       and three times three is 9!"/utf8>>,
+    bd"Two plus two is ~2 + 2~,
+       and three times three is ~3 * 3~!"
+  ),
+  ?assertEqualStr(
+    "Two plus two is 4,
+       and three times three is 9!",
+    ld"Two plus two is ~2 + 2~,
+       and three times three is ~3 * 3~!"
+  ).
+
+lots_of_subs(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"A 4, B 6, C 81, D -6, E 0, F 8"/utf8>>,
+    bf"A ~2 + 2~, B ~3 + 3~, C ~9 * 9~, D ~-6~, E ~0~, F ~2 * (2 + 2)~"
+  ),
+  ?assertEqualStr(
+    "A 4, B 6, C 81, D -6, E 0, F 8",
+    lf"A ~2 + 2~, B ~3 + 3~, C ~9 * 9~, D ~-6~, E ~0~, F ~2 * (2 + 2)~"
+  ),
+  ?assertEqual(
+    <<"A 4, B 6, C 81, D -6, E 0, F 8"/utf8>>,
+    bd"A ~2 + 2~, B ~3 + 3~, C ~9 * 9~, D ~-6~, E ~0~, F ~2 * (2 + 2)~"
+  ),
+  ?assertEqualStr(
+    "A 4, B 6, C 81, D -6, E 0, F 8",
+    ld"A ~2 + 2~, B ~3 + 3~, C ~9 * 9~, D ~-6~, E ~0~, F ~2 * (2 + 2)~"
+  ).
+
+tilde_can_be_escaped(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Two plus t\~wo is ~4!"/utf8>>,
+    bf"Two plus t\~wo is \~~2 + 2~!"
+  ),
+  ?assertEqualStr(
+    "Two plus t\~wo is ~4!",
+    lf"Two plus t\~wo is \~~2 + 2~!"
+  ),
+  ?assertEqual(
+    <<"Two plus t\~wo is ~4!"/utf8>>,
+    bd"Two plus t\~wo is \~~2 + 2~!"
+  ),
+  ?assertEqualStr(
+    "Two plus t\~wo is ~4!",
+    ld"Two plus t\~wo is \~~2 + 2~!"
+  ).
+
+unicode_list_string_subs_in_list(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Emoji: 🙂👍"/utf8>>,
+    bf"Emoji: ~[$🙂, $👍]~"
+  ),
+  ?assertEqualStr(
+    "Emoji: 🙂👍",
+    lf"Emoji: ~[$🙂, $👍]~"
+  ),
+  ?assertEqual(
+    <<"Emoji: [128578,128077]"/utf8>>,
+    bd"Emoji: ~[$🙂, $👍]~"
+  ),
+  ?assertEqualStr(
+    "Emoji: [128578,128077]",
+    ld"Emoji: ~[$🙂, $👍]~"
+  ).
+
+utf8_binary_string_subs_in_list(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Emoji: 🙂👍"/utf8>>,
+    bf"Emoji: ~<<"🙂👍"/utf8>>~"
+  ),
+  ?assertEqualStr(
+    "Emoji: 🙂👍",
+    lf"Emoji: ~<<"🙂👍"/utf8>>~"
+  ),
+  ?assertEqual(
+    <<"Emoji: <<240,159,153,130,240,159,145,141>>"/utf8>>,
+    bd"Emoji: ~<<"🙂👍"/utf8>>~"
+  ),
+  ?assertEqualStr(
+    "Emoji: <<240,159,153,130,240,159,145,141>>",
+    ld"Emoji: ~<<"🙂👍"/utf8>>~"
+  ).
+
+unicode_list_string_subs_in_tuple(Config) when is_list(Config) ->
+  ?assertError(
+    badarg,
+    bf"Emoji: ~{a,[$🙂,$👍],c}~"
+  ),
+  ?assertError(
+    badarg,
+    lf"Emoji: ~{a,[$🙂,$👍],c}~"
+  ),
+  ?assertEqual(
+    <<"Emoji: {a,[128578,128077],c}"/utf8>>,
+    bd"Emoji: ~{a,[$🙂,$👍],c}~"
+  ),
+  ?assertEqualStr(
+    "Emoji: {a,[128578,128077],c}",
+    ld"Emoji: ~{a,[$🙂,$👍],c}~"
+  ).
+
+utf8_binary_string_subs_in_tuple(Config) when is_list(Config) ->
+  ?assertError(
+    badarg,
+    bf"Emoji: ~{a,<<"🙂👍"/utf8>>,c}~"
+  ),
+  ?assertError(
+    badarg,
+    lf"Emoji: ~{a,<<"🙂👍"/utf8>>,c}~"
+  ),
+  ?assertEqual(
+    <<"Emoji: {a,<<240,159,153,130,240,159,145,141>>,c}"/utf8>>,
+    bd"Emoji: ~{a,<<"🙂👍"/utf8>>,c}~"
+  ),
+  ?assertEqualStr(
+    "Emoji: {a,<<240,159,153,130,240,159,145,141>>,c}",
+    ld"Emoji: ~{a,<<"🙂👍"/utf8>>,c}~"
+  ).
+
+variable_subs(Config) when is_list(Config) ->
+  X = 2 + 2,
+  ?assertEqual(
+    <<"X: 4"/utf8>>,
+    bf"X: ~X~"
+  ),
+  ?assertEqualStr(
+    "X: 4",
+    lf"X: ~X~"
+  ),
+  ?assertEqual(
+    <<"X: 4"/utf8>>,
+    bd"X: ~X~"
+  ),
+  ?assertEqualStr(
+    "X: 4",
+    ld"X: ~X~"
+  ).
+
+macro_subs(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"This module: erl_desugar_interpolation_SUITE"/utf8>>,
+    bf"This module: ~?MODULE~"
+  ),
+  ?assertEqualStr(
+    "This module: erl_desugar_interpolation_SUITE",
+    lf"This module: ~?MODULE~"
+  ),
+  ?assertEqual(
+    <<"This module: erl_desugar_interpolation_SUITE"/utf8>>,
+    bd"This module: ~?MODULE~"
+  ),
+  ?assertEqualStr(
+    "This module: erl_desugar_interpolation_SUITE",
+    ld"This module: ~?MODULE~"
+  ).
+
+special_characters(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"\nstuff\tmore stuff: \neven more stuff"/utf8>>,
+    bf"\nstuff\tmore stuff: ~<<"\n"/utf8>>~even more stuff"
+  ),
+  ?assertEqualStr(
+    "\nstuff\tmore stuff: \neven more stuff",
+    lf"\nstuff\tmore stuff: ~<<"\n"/utf8>>~even more stuff"
+  ),
+  ?assertEqual(
+    <<"\nstuff\tmore stuff: <<10>>even more stuff"/utf8>>,
+    bd"\nstuff\tmore stuff: ~<<"\n"/utf8>>~even more stuff"
+  ),
+  ?assertEqualStr(
+    "\nstuff\tmore stuff: <<10>>even more stuff",
+    ld"\nstuff\tmore stuff: ~<<"\n"/utf8>>~even more stuff"
+  ).
+
+back_to_back_substitutions(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Here are several expression back-to-back 3my_atomfoo"/utf8>>,
+    bf"Here are several expression back-to-back ~1+2~~my_atom~~<<"foo"/utf8>>~"
+  ),
+  ?assertEqualStr(
+    "Here are several expression back-to-back 3my_atomfoo",
+    lf"Here are several expression back-to-back ~1+2~~my_atom~~<<"foo"/utf8>>~"
+  ),
+  ?assertEqual(
+    <<"Here are several expression back-to-back 3my_atom<<102,111,111>>"/utf8>>,
+    bd"Here are several expression back-to-back ~1+2~~my_atom~~<<"foo"/utf8>>~"
+  ),
+  ?assertEqualStr(
+    "Here are several expression back-to-back 3my_atom<<102,111,111>>",
+    ld"Here are several expression back-to-back ~1+2~~my_atom~~<<"foo"/utf8>>~"
+  ).
+
+all_production_format_types_subs(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"integer: 2
+       atom: foo
+       list-string: a string
+       binary-string: another string">>,
+    bf"integer: ~1 + 1~
+       atom: ~foo~
+       list-string: ~"a string"~
+       binary-string: ~<<"another string"/utf8>>~"
+    ),
+  ?assertEqualStr(
+    "integer: 2
+       atom: foo
+       list-string: a string
+       binary-string: another string",
+    lf"integer: ~1 + 1~
+       atom: ~foo~
+       list-string: ~"a string"~
+       binary-string: ~<<"another string"/utf8>>~"
+    ),
+  ?assertEqual(
+    <<"integer: 2
+       atom: foo
+       list-string: [97,32,115,116,114,105,110,103]
+       binary-string: <<97,110,111,116,104,101,114,32,115,116,114,105,110,103>>">>,
+    bd"integer: ~1 + 1~
+       atom: ~foo~
+       list-string: ~"a string"~
+       binary-string: ~<<"another string"/utf8>>~"
+    ),
+  ?assertEqualStr(
+    "integer: 2
+       atom: foo
+       list-string: [97,32,115,116,114,105,110,103]
+       binary-string: <<97,110,111,116,104,101,114,32,115,116,114,105,110,103>>",
+    ld"integer: ~1 + 1~
+       atom: ~foo~
+       list-string: ~"a string"~
+       binary-string: ~<<"another string"/utf8>>~"
+    ).
+
+floats_round_trip_and_are_the_same_between_lists_and_binaries(Config) when is_list(Config) ->
+  ?assertError(
+    badarg,
+    bf"A float: ~1000000000000 + 0.1 + 0.2~"
+  ),
+  ?assertError(
+    badarg,
+    lf"A float: ~1000000000000 + 0.1 + 0.2~"
+  ),
+  ?assertEqual(
+    <<"A float: 1000000000000.2999"/utf8>>,
+    bd"A float: ~1000000000000 + 0.1 + 0.2~"
+  ),
+  ?assertEqualStr(
+    "A float: 1000000000000.2999",
+    ld"A float: ~1000000000000 + 0.1 + 0.2~"
+  ),
+  ?assertEqual(
+     1000000000000 + 0.1 + 0.2,
+     binary_to_float(string:trim(bd"~1000000000000 + 0.1 + 0.2~", both, [$"]))
+  ),
+  ?assertEqual(
+     1000000000000 + 0.1 + 0.2,
+     list_to_float(string:trim(ld"~1000000000000 + 0.1 + 0.2~", both, [$"]))
+  ),
+  ?assertEqual(
+     binary_to_float(string:trim(bd"~1000000000000 + 0.1 + 0.2~", both, [$"])),
+     list_to_float(string:trim(ld"~1000000000000 + 0.1 + 0.2~", both, [$"]))
+  ).
+
+all_types_subs(Config) when is_list(Config) ->
+  ?assertError(
+    badarg,
+    bf"integer: ~1 + 1~
+       float: ~2.0 * 2.0~
+       atom: ~foo~
+       port: ~open_port({spawn, ls}, [])~
+       pid: ~self()~
+       ref: ~make_ref()~
+       bitstring: ~<<6:4>>~
+       list: ~[1,2,3]~
+       tuple: ~{1,b,3.0}~
+       map: ~#{key => value}~
+       function: ~fun (X) -> X + 1 end~"
+    ),
+  ?assertError(
+    badarg,
+    lf"integer: ~1 + 1~
+       float: ~2.0 * 2.0~
+       atom: ~foo~
+       port: ~open_port({spawn, ls}, [])~
+       pid: ~self()~
+       ref: ~make_ref()~
+       bitstring: ~<<6:4>>~
+       list: ~[1,2,3]~
+       tuple: ~{1,b,3.0}~
+       map: ~#{key => value}~
+       function: ~fun (X) -> X + 1 end~"
+    ),
+  InterpolatedBd =
+    bd"integer: ~1 + 1~
+       float: ~2.0 * 2.0~
+       atom: ~foo~
+       port: ~open_port({spawn, ls}, [])~
+       pid: ~self()~
+       ref: ~make_ref()~
+       bitstring: ~<<6:4>>~
+       list: ~[1,2,3]~
+       tuple: ~{1,b,3.0}~
+       map: ~#{key => value}~
+       function: ~fun (X) -> X + 1 end~",
+  ?assert(
+    is_binary(InterpolatedBd)
+  ),
+  ?assertMatch(
+    {match, _},
+    re:run(
+      InterpolatedBd,
+      <<"integer: 2
+       float: 4\\.0
+       atom: foo
+       port: #Port<.*>
+       pid: <.*>
+       ref: #Ref<.*>
+       bitstring: <<6:4>>
+       list: \\[1,2,3\\]
+       tuple: \\{1,b,3\.0\\}
+       map: #\\{key => value\\}
+       function: #Fun<erl_desugar_interpolation_SUITE.*>">>,
+      [multiline]
+     ),
+    lists:flatten(io_lib:format("Interpolation (binary, debug) result was:~n~ts~n", [InterpolatedBd]))
+  ),
+  InterpolatedLd =
+    ld"integer: ~1 + 1~
+       float: ~2.0 * 2.0~
+       atom: ~foo~
+       port: ~open_port({spawn, ls}, [])~
+       pid: ~self()~
+       ref: ~make_ref()~
+       bitstring: ~<<6:4>>~
+       list: ~[1,2,3]~
+       tuple: ~{1,b,3.0}~
+       map: ~#{key => value}~
+       function: ~fun (X) -> X + 1 end~",
+  ?assert(
+    is_list(InterpolatedLd)
+  ),
+  ?assertMatch(
+    {match, _},
+    re:run(
+      InterpolatedLd,
+      "integer: 2
+       float: 4\\.0
+       atom: foo
+       port: #Port<.*>
+       pid: <.*>
+       ref: #Ref<.*>
+       bitstring: <<6:4>>
+       list: \\[1,2,3\\]
+       tuple: \\{1,b,3\.0\\}
+       map: #\\{key => value\\}
+       function: #Fun<erl_desugar_interpolation_SUITE.*>",
+      [multiline]
+     ),
+    lists:flatten(io_lib:format("Interpolation (list, debug) result was:~n~ts~n", [InterpolatedLd]))
+  ).
+
+function_call_substitutions(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"erlang:is_binary(\"hi\") = false"/utf8>>,
+    bf"erlang:is_binary(\"hi\") = ~erlang:is_binary("hi")~"
+  ),
+  ?assertEqualStr(
+    "erlang:is_binary(\"hi\") = false",
+    lf"erlang:is_binary(\"hi\") = ~erlang:is_binary("hi")~"
+  ),
+  ?assertEqual(
+    <<"erlang:is_binary(\"hi\") = false"/utf8>>,
+    bd"erlang:is_binary(\"hi\") = ~erlang:is_binary("hi")~"
+  ),
+  ?assertEqualStr(
+    "erlang:is_binary(\"hi\") = false",
+    ld"erlang:is_binary(\"hi\") = ~erlang:is_binary("hi")~"
+  ).
+
+block_substitutions(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"block value: 7"/utf8>>,
+    bf"block value: ~begin A = 6, (fun (X) -> X + 1 end)(A) end~"
+  ),
+  ?assertEqualStr(
+    "block value: 7",
+    lf"block value: ~begin A = 6, (fun (X) -> X + 1 end)(A) end~"
+  ),
+  ?assertEqual(
+    <<"block value: 7"/utf8>>,
+    bd"block value: ~begin A = 6, (fun (X) -> X + 1 end)(A) end~"
+  ),
+  ?assertEqualStr(
+    "block value: 7",
+    ld"block value: ~begin A = 6, (fun (X) -> X + 1 end)(A) end~"
+  ).
+
+homogenous_interpolations_inside_interpolations(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Yo dawg, I heard you like string interpolations, so I put a string in your string so you can interpolate while you interpolate"/utf8>>,
+    bf"Yo dawg, I heard you like string interpolations, ~bf"so I put a ~bf"string in your"~ string"~ so you can interpolate while you interpolate"
+  ),
+  ?assertEqualStr(
+    "Yo dawg, I heard you like string interpolations, so I put a string in your string so you can interpolate while you interpolate",
+    lf"Yo dawg, I heard you like string interpolations, ~lf"so I put a ~lf"string in your"~ string"~ so you can interpolate while you interpolate"
+  ),
+  ?assertEqual(
+    <<"Yo dawg, I heard you like string interpolations, <<115,111,32,73,32,112,117,116,32,97,32,60,60,49,49,53,44,49,49,54,44,49,49,52,44,49,48,53,44,49,49,48,44,49,48,51,44,51,50,44,49,48,53,44,49,49,48,44,51,50,44,49,50,49,44,49,49,49,44,49,49,55,44,49,49,52,62,62,32,115,116,114,105,110,103>> so you can interpolate while you interpolate"/utf8>>,
+    bd"Yo dawg, I heard you like string interpolations, ~bd"so I put a ~bd"string in your"~ string"~ so you can interpolate while you interpolate"
+  ),
+  ?assertEqualStr(
+    "Yo dawg, I heard you like string interpolations, [[115,111,32,73,32,112,117,116,32,97,32],[91,[[49,49,53],44,[49,49,54],44,[49,49,52],44,[49,48,53],44,[49,49,48],44,[49,48,51],44,[51,50],44,[49,48,53],44,[49,49,48],44,[51,50],44,[49,50,49],44,[49,49,49],44,[49,49,55],44,[49,49,52]],93],[32,115,116,114,105,110,103]] so you can interpolate while you interpolate",
+    ld"Yo dawg, I heard you like string interpolations, ~ld"so I put a ~ld"string in your"~ string"~ so you can interpolate while you interpolate"
+  ).
+
+heterogenous_interpolations_inside_interpolations(Config) when is_list(Config) ->
+  ?assertEqual(
+    <<"Yo dawg, I heard you like string interpolations, so I put a string in your string so you can interpolate while you interpolate"/utf8>>,
+    bf"Yo dawg, I heard you like string interpolations, ~lf"so I put a ~bd"string in your"~ string"~ so you can interpolate while you interpolate"
+  ),
+  ?assertEqualStr(
+    "Yo dawg, I heard you like string interpolations, so I put a string in your string so you can interpolate while you interpolate",
+    lf"Yo dawg, I heard you like string interpolations, ~bf"so I put a ~ld"string in your"~ string"~ so you can interpolate while you interpolate"
+  ),
+  ?assertEqual(
+    <<"Yo dawg, I heard you like string interpolations, [[115,111,32,73,32,112,117,116,32,97,32],[60,60,[[49,49,53],44,[49,49,54],44,[49,49,52],44,[49,48,53],44,[49,49,48],44,[49,48,51],44,[51,50],44,[49,48,53],44,[49,49,48],44,[51,50],44,[49,50,49],44,[49,49,49],44,[49,49,55],44,[49,49,52]],62,62],[32,115,116,114,105,110,103]] so you can interpolate while you interpolate"/utf8>>,
+    bd"Yo dawg, I heard you like string interpolations, ~ld"so I put a ~bf"string in your"~ string"~ so you can interpolate while you interpolate"
+  ),
+  ?assertEqualStr(
+    "Yo dawg, I heard you like string interpolations, <<115,111,32,73,32,112,117,116,32,97,32,91,49,49,53,44,49,49,54,44,49,49,52,44,49,48,53,44,49,49,48,44,49,48,51,44,51,50,44,49,48,53,44,49,49,48,44,51,50,44,49,50,49,44,49,49,49,44,49,49,55,44,49,49,52,93,32,115,116,114,105,110,103>> so you can interpolate while you interpolate",
+    ld"Yo dawg, I heard you like string interpolations, ~bd"so I put a ~lf"string in your"~ string"~ so you can interpolate while you interpolate"
+  ).

--- a/system/doc/reference_manual/data_types.xml
+++ b/system/doc/reference_manual/data_types.xml
@@ -358,7 +358,7 @@ a
 
   <section>
     <title>String</title>
-    <p>Strings are enclosed in double quotes ("), but is not a
+    <p>Strings literals are enclosed in double quotes ("), but is not a
       data type in Erlang. Instead, a string <c>"hello"</c> is
       shorthand for the list <c>[$h,$e,$l,$l,$o]</c>, that is,
       <c>[104,101,108,108,111]</c>.</p>
@@ -370,6 +370,69 @@ a
     <p>is equivalent to</p>
     <pre>
 "string42"</pre>
+
+    <section>
+      <title>String interpolation</title>
+      <p>Interpolated strings are string literals which allow other
+      expressions to be embedded into the,m. Interpolated strings format
+      the expressions they contain, and substitute their values into
+      the resulting string. Any expression can be placed inside an interpolated
+      string, including variables, function calls, macros, comprehensions,
+      and even other interpolated strings.
+      </p>
+
+      <p>Interpolated strings offer a more readable alternative to
+      <seemfa marker="stdlib:io_lib#format/2"><c>io_lib:format/2</c></seemfa>
+      and related formatting functions by keeping the interpolated
+      expressions in the position that their formatted value will
+      appear in the resulting string.
+      </p>
+
+    <p><em>Example:</em></p>
+    <pre>
+Name = "Alice".
+
+get_unread_messages() ->
+  [ {"Bob", "Let's grab lunch after the meeting?"},
+    {"Charlie", "When would you like that report submitting?"}
+  ].
+
+1> <input>io_lib:format("Hello ~ts, you have ~B unread messages.", [Name, length(get_unread_messages())]).</input>
+"Hello Alice, you have 2 unread messages."
+2> <input>lf"Hello ~Name~, you have ~get_unread_messages()~ unread messages."</input>
+"Hello Alice, you have 2 unread messages."
+</pre>
+
+    <p>There are four forms of interpolated strings, differentiated by their prefix:</p>
+    <list type="bulleted">
+      <item><c>lf"..."</c> ("list format"), for strictly formatting unicode-codepoint-list strings</item>
+      <item><c>bf"..."</c> ("binary format"), for strictly formatting UTF-8-encoded binary strings</item>
+      <item><c>ld"..."</c> ("list debug"), for flexibly formatting unicode-codepoint-list strings</item>
+      <item><c>bd"..."</c> ("binary debug"), for flexibly formatting UTF-8-encoded binary strings</item>
+    </list>
+
+    <p>The list variants are typically most useful for backwards compatibility
+    and convenience. The binary variants are typically most useful for
+    memory-compactness and interacting with external systems.
+    </p>
+
+    <p>Whilst the list and binary variants yield unicode codepoint lists
+    and UTF-8-encoded binaries respectively, they both accept each other
+    as interpolated values.
+    </p>
+
+    <p>The <c>lf"..."</c> and <c>bf"..."</c> variants accept only unicode
+    codepoint lists, UTF-8-encoded binaries or integers as interpolated values,
+    with the expectation that more complex formatting decisions would be
+    factored out into interpolated function calls which can be tested and reused
+    in isolation.
+    </p>
+
+    <p>The <c>ld"..."</c> and <c>bd"..."</c> variants accept any Erlang term,
+    and are focussed around logging and debugging.
+    </p>
+
+    </section>
   </section>
 
   <section>


### PR DESCRIPTION
Adds four kinds of string interpolation split over two axes (utf-8 binary or unicode codepoint list, and user-facing or developer-facing formatting).

The result are four general classes of syntax with interpolated values:

```
% binary format
<<"A utf-8 binary string: 4"/utf8>> =
  bf"A utf-8 binary string: ~2 + 2~"
```

```
% list format
"A unicode codepoint list string: 4" =
  lf"A unicode codepoint list string: ~2 + 2~"
```

```
% binary debug
<<"A utf-8 binary string: {4, foo, [x, y, z]}"/utf8>> =
  bd"A utf-8 binary string: ~{2 + 2, foo, [x, y, z]}~"
```

```
% list debug
"A unicode codepoint list string: {4, foo, [x, y, z]}" =
  ld"A unicode codepoint list string: ~{2 + 2, foo, [x, y, z]}~"
```

Arbitrary expressions can be nested inside string interpolation substitutions, including variables, function calls, macros and even further string interpolation expressions.

Design
======

Why list- and binary-strings?
-----------------------------

In the `string` module from the stdlib, a string is represented by `unicode:chardata()`, that is, a list of codepoints, binaries with UTF-8-encoded codepoints (UTF-8 binaries), or a mix of the two.

With this in mind, the list- and binary-oriented string interpolation syntaxes accept either type of interpolated value, but the user of the interpolation determines whether they want to generate a `unicode:char_list()` or `unicode:unicode_binary()` based on which kind of interpolation they use (`bf"..."` and `bd"..."` to create binaries, or `lf"..."` and `ld"..."` to create lists).

List-strings are most useful for backwards compatibility and convenience. Binary-strings are most useful for memory-compactness and IO.

Why user- and developer-oriented strings?
-----------------------------------------

There are two similar, but distinct cases where developers typically want to format strings: when logging/debugging, and when displaying data to users.

When logging or debugging, the most important features are typically that any kind of term can be printed, and it should round-trip losslessly and be read by developers unambiguously. Examples of these properties are, for example, retaining runtime type information, e.g. keeping strings quoted when formatting them and printing floats with full range and resolution.

When displaying to users, the most important features are typically that they are always going to be human-readable and cleanly formatted. Examples of these properties are, for example, formatting strings verbatim, without quotation marks, and not retaining any Erlang-isms (e.g. we don't want to be printing Erlang tuples, because they won't make much sense to the average application consumer), so we'd rather get a `badarg` error to push the developer to make an explicit formatting decision.

Why no formatting options?
--------------------------

Let's consider the two use-cases introduced earlier:

- Logging/debugging: Typically you want to fire-and-forget, giving whatever value you care about to the formatter, and just let it print that value unambiguously, meaning there's no need to tweak formatting options: `bd"~Timestamp~: ~Query~ returned ~Result~"`
- Displaying to users: Typically you want to tightly control formatting, and you probably want to do so in a modular and reusable way. In that case, factoring out your formatting decision to a function, and interpolating the result of that function is probably the best way to go: `bf"You account balance is now ~my_app:format_balance(Currency, Balance)~"`.

Notably, nothing in the design and implementation here precludes the future introduction of formatting options such as `bf"float: ~.2f(MyFloat)~"` as one might do with `io_lib:format` etc. But existing stdlib functions can offer similar functionality, e.g. `bf"float: ~float_to_binary(MyFloat, [{decimals, 2}, compact])~"`, and can be factored out into their own reusable functions.

Implementation
==============

To parse interpolated strings, the scanner tracks some additional state regarding whether we are currently in an interpolated string, at which point it enables the recognition of `~` as the delimiter for interpolated expressions, and generates new tokens which represent the various components of an interpolated string.

Early during compilation and shell evaluation, interpolated strings are desugared into calls to functions from the `io_lib` module, and therefore don't impact later stages of compilation or evalution.

The new string interpolation syntax was not previously valid syntax, so should be entirely backwards compatible with existing source code.